### PR TITLE
Change error level viewer layout

### DIFF
--- a/src/viewers/ErrorLevelViewer.js
+++ b/src/viewers/ErrorLevelViewer.js
@@ -19,9 +19,11 @@ const useColorStyle = makeStyles(theme => ({
 
 const useBackgroundStyle = makeStyles(theme => ({
     root: {
-        padding: theme.spacing(.5, 1),
+        padding: theme.spacing(.5, 0.1),
         borderRadius: theme.spacing(1),
-        textAlign: 'center'
+        display: 'flex',
+        alignItems: 'center',
+        textTransform: 'capitalize'
     },
     error: {
         background: theme.palette.error.light,
@@ -49,5 +51,15 @@ export default (levelProjection, mode) => ({ value, item }) => {
         ? '-'
         : String(value);
 
-    return <div className={clsx(classes.root, classes[levelProjection(item)])}>{str}</div>;
+    return (
+      <div className={clsx(classes.root)}>
+        <div style={{ width: "10%" }}>
+          <div
+            style={{ width: "10px", height: "10px", borderRadius: "50%" }}
+            className={classes[levelProjection(item)]}
+          ></div>
+        </div>
+        <div style={{ width: "90%" }}>{str}</div>
+      </div>
+    ); 
 };


### PR DESCRIPTION

The design of the column "Notification Level" is changed, the first letter is capitalized and the background is changed to a circle of the same color and they are aligned to the left


**Before** 
![before](https://user-images.githubusercontent.com/81880890/130632469-f38711e9-0c89-4d95-ba80-f6c11d574e91.png)





**Now**

![now](https://user-images.githubusercontent.com/81880890/130632516-a236084c-f71b-4843-aad7-ad364d4d2745.png)
