### PR TITLE
Features/side bar sticky avatar movil view

### DIFF
--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -29,7 +29,11 @@ const useStyles = makeStyles(theme => ({
     avatarContentWrapper: {
             width: '90%',
             margin: '0 auto',
-            borderBottom: `2px solid ${theme.palette.primary.light}`
+            borderBottom: `2px solid ${theme.palette.primary.light}`,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1500,
+            background: '#fff',
     },
     danger: {
         color: theme.palette.error.main


### PR DESCRIPTION
The content of the user's card is fixed in the mobile view so that it only scrolls the menu elements

https://user-images.githubusercontent.com/81880890/130646309-eeaf9d5a-401e-40bd-801c-5ef618445d2e.mp4

**This PR is from the branch "features / sideBar-separator" it must be mixed after the PR of the parent branch**