### PR TITLE
Fix the design, adding separation in the elements

### DIFF
--- a/src/viewers/ErrorLevelViewer.js
+++ b/src/viewers/ErrorLevelViewer.js
@@ -53,7 +53,7 @@ export default (levelProjection, mode) => ({ value, item }) => {
 
     return (
       <div className={clsx(classes.root)}>
-        <div style={{ width: "10%" }}>
+        <div style={{ marginRight: "0.5rem"}}>
           <div
             style={{ width: "10px", height: "10px", borderRadius: "50%" }}
             className={classes[levelProjection(item)]}


### PR DESCRIPTION
Items in the notification cell are adjusted so that they do not overlap

**BEFORE**
![BeforNL2](https://user-images.githubusercontent.com/81880890/131370363-bfcb5dd5-3af9-40a9-8d0c-d7823e16f19c.png)
![BeforeNL1](https://user-images.githubusercontent.com/81880890/131370382-7b361213-b5c0-4c61-a818-8c5b2a732a5c.png)

**NOW**

![AfterNL1](https://user-images.githubusercontent.com/81880890/131370469-31625ebf-4fe6-47cf-a638-541efe7e28d8.png)
![AfterNL2](https://user-images.githubusercontent.com/81880890/131370502-8d1d4987-04e3-4d0c-a4bf-be1df63c5bb7.png)
