### PR TITLE
Change background color and padding to CollectionActionToolbar

### DIFF
--- a/src/actions/CollectionActionsToolbar.js
+++ b/src/actions/CollectionActionsToolbar.js
@@ -16,9 +16,10 @@ import IconButton from "@material-ui/core/IconButton";
 const useToolbarStyles = makeStyles(theme => ({
     root: {
         display: 'flex',
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(1),
-        height: appBarHeight(theme)
+        paddingLeft: theme.spacing(4),
+        paddingRight: theme.spacing(4),
+        height: appBarHeight(theme),
+        backgroundColor: theme.palette.background.default,
     },
     title: {
         flex: '0 0 auto',


### PR DESCRIPTION
The content of the action bar is spaced and the background is changed from white to the default background

**BEFORE**
![BeforeColletionHeader](https://user-images.githubusercontent.com/81880890/131393094-f9f4c1f6-2f01-45b8-8a14-a97258e6153a.png)

**NOW**
![NowColletionHeader](https://user-images.githubusercontent.com/81880890/131393083-e9a2b348-1954-434d-9e75-90dd981b302b.png)

