### PR TITLE
Adding property containerTitle to ContainerContext and change paginat…

### DIFF
--- a/src/actions/CollectionContainer.js
+++ b/src/actions/CollectionContainer.js
@@ -128,6 +128,10 @@ function CollectionContainerLayout({ docked, subject, height, width, onSubjectPi
     const { dataTypeId } = subject;
 
     useEffect(() => {
+        setContainerState({containerTitle: title})
+    }, [title, setContainerState])
+    
+    useEffect(() => {
         if (activeActionKey) {
             setContainerState({ actionKey: activeActionKey });
         }

--- a/src/actions/Index.js
+++ b/src/actions/Index.js
@@ -292,7 +292,7 @@ function DefaultIndex({ dataType, subject, height, width, dataTypeConfig }) {
 
     const [containerState, setContainerState] = useContainerContext();
 
-    const { data, page, limit, props, itemsViewport, selector } = containerState;
+    const { data, page, limit, props, itemsViewport, selector, containerTitle } = containerState;
 
     const classes = useStyles();
     const theme = useTheme();
@@ -409,7 +409,7 @@ function DefaultIndex({ dataType, subject, height, width, dataTypeConfig }) {
                 <div className={clsx('flex align-items-center', classes.pagination, classes.pageShadow)}>
                     <div className="grow-1"/>
                     <Typography variant="subtitle2">
-                        Page size
+                    {containerTitle} per page
                     </Typography>
                     <Select className={classes.pageSize}
                             value={limit}


### PR DESCRIPTION
The "containerTitle" property is added to the ContainerContext context and the paging subtitle is changed by adding the name of the model that corresponds to the table listing


**BEFORE**
![PaginationDTypesBefor](https://user-images.githubusercontent.com/81880890/131560777-b61d3258-01c1-4194-aa2f-7b3231a2cd67.png)
![PaginationTenantsBefore](https://user-images.githubusercontent.com/81880890/131560784-19455811-ddae-43ff-b391-b5b76338dc1c.png)

**NOW**
![PaginationDTypesNow](https://user-images.githubusercontent.com/81880890/131560816-50355077-3d37-4561-a60f-fffa58c27937.png)
![PaginationTenantsNow](https://user-images.githubusercontent.com/81880890/131560824-eb39612f-89ed-479f-b960-b06686e1e422.png)

