### PR TITLE
Adding max-height to cardWrapper

### DIFF
--- a/src/components/FormEditor.js
+++ b/src/components/FormEditor.js
@@ -92,6 +92,7 @@ const useStyles = makeStyles(theme => ({
         backgroundColor: theme.palette.background.paper,
         boxShadow: "0 2px 5px 1px rgb(64 60 67 / 16%)",
         borderRadius: "6px",
+        maxHeight: props => `calc(${props.height} - ${theme.spacing(stackHeaderSpacing)}px - 4.6rem)`,
     },
     fabBack: {
         position: 'absolute',


### PR DESCRIPTION
Adjust the size of the container so that it does not overflow 

**Before**

https://user-images.githubusercontent.com/81880890/135306143-bf7a3aa1-ff5d-4857-ac49-429fd2f31d68.mp4


**NOW**

https://user-images.githubusercontent.com/81880890/135306164-337ef3ba-3282-469c-b4e7-c46ada5962a4.mp4

