### PR TITLE
Fixing breadcrumb layout in mobile views

### DIFF
--- a/src/actions/CollectionActionsToolbar.js
+++ b/src/actions/CollectionActionsToolbar.js
@@ -16,14 +16,24 @@ import IconButton from "@material-ui/core/IconButton";
 const useToolbarStyles = makeStyles(theme => ({
     root: {
         display: 'flex',
-        paddingLeft: theme.spacing(4),
-        paddingRight: theme.spacing(4),
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(0),
         height: appBarHeight(theme),
         backgroundColor: theme.palette.background.default,
+          [theme.breakpoints.up('sm')]: {
+            paddingLeft: theme.spacing(4),
+            paddingRight: theme.spacing(4),
+        },
     },
     title: {
         flex: '0 0 auto',
-        color: theme.palette.primary.dark
+        color: theme.palette.primary.dark,
+        maxWidth: () => `calc(100vw - 190px)`,
+    },
+    titleText: {
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden'
     },
     filterIcon: {
         color: theme.palette.getContrastText(theme.palette.secondary.main)
@@ -177,7 +187,7 @@ function CollectionActionsToolbar({ dataType, title, selectedKey, onSubjectPicke
     return (
         <Toolbar className={classes.root}>
             <div className={classes.title}>
-                <Typography variant="h6">
+                <Typography variant="h6" className={classes.titleText}>
                    { mainSectionTitle && `${mainSectionTitle} |`} {title}
                 </Typography>
             </div>


### PR DESCRIPTION
**Breadcrumbs Design Proposal # 2 in Mobile Views**
Text is preserved and styled to fit content


**Before**

https://user-images.githubusercontent.com/81880890/136295654-f2a3245e-0d49-4367-a179-f6a15c8e31e9.mp4

**NOW**

https://user-images.githubusercontent.com/81880890/136295717-007dcb30-8c9d-48dc-8559-0382c693aed3.mp4

