### PR TITLE
Adding action name show and edit to breadcrumb

### DIFF
--- a/src/actions/CollectionActionsToolbar.js
+++ b/src/actions/CollectionActionsToolbar.js
@@ -187,7 +187,7 @@ function CollectionActionsToolbar({ dataType, title, selectedKey, onSubjectPicke
     return (
         <Toolbar className={classes.root}>
             <div className={classes.title}>
-                <Typography variant="h6"> 
+                <Typography variant="h6" className={classes.titleText}> 
                    { mainSectionTitle && `${mainSectionTitle} |`} {title}  { breadcrumbActionName && ` | ${breadcrumbActionName}`}
                 </Typography>
             </div>

--- a/src/actions/MemberContainer.js
+++ b/src/actions/MemberContainer.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import Loading from '../components/Loading';
-import { Breadcrumbs, Chip, Toolbar, Typography, useTheme } from "@material-ui/core";
+import { Breadcrumbs, Chip, Toolbar, Typography, useMediaQuery, useTheme } from "@material-ui/core";
 import { appBarHeight } from "../layout/AppBar";
 import ActionRegistry, { ActionKind } from "./ActionRegistry";
 import { makeStyles } from '@material-ui/core/styles';
@@ -94,10 +94,12 @@ function MemberContainerLayout({ docked, subject, height, width, onSubjectPicked
 
     const tenantContext = useTenantContext();
 
-    const { dataType, record, loading, actionKey, actionComponentKey } = containerState;
+    const { dataType, record, loading, actionKey, actionComponentKey,breadcrumbActionName } = containerState;
 
     const actionSubscription = useRef(null);
     const theme = useTheme();
+    const xs = useMediaQuery(theme.breakpoints.down('xs'));
+
     const classes = useActionContainerStyles({ width, height });
 
     const { dataTypeTitle, title, error, disabled } = state;
@@ -230,6 +232,11 @@ function MemberContainerLayout({ docked, subject, height, width, onSubjectPicked
         <Typography variant="h6" className={classes.recordTitle}>
           {title || <Skeleton variant="text" width={theme.spacing(5)} />}
         </Typography>
+        {breadcrumbActionName && !xs && (
+          <Typography variant="h6" className={classes.recordTitle}>
+            {breadcrumbActionName}
+          </Typography>
+        )}
       </Breadcrumbs>
     );
 

--- a/src/actions/Show.js
+++ b/src/actions/Show.js
@@ -6,6 +6,7 @@ import Fab from "@material-ui/core/Fab";
 import EditIcon from "@material-ui/icons/Edit";
 import FormEditor from "../components/FormEditor";
 import { useSpreadState } from "../common/hooks";
+import { useContainerContext } from './ContainerContext';
 
 const useStyles = makeStyles(theme => ({
     editButton: {
@@ -20,9 +21,20 @@ const Show = ({ docked, dataType, record, onSubjectPicked, onUpdate, height }) =
         readOnly: true
     });
 
+    const containerContext = useContainerContext();
+    const [, setContainerState] = containerContext;
+
     const { readOnly, config } = state;
 
     const classes = useStyles();
+
+    useEffect(() => {
+        setContainerState({ breadcrumbActionName: readOnly ? "Show" : "Edit" });
+  
+        return () => {
+          setContainerState({ breadcrumbActionName: null });
+        };
+      }, [readOnly]);
 
     useEffect(() => {
         const subscription = dataType.config().subscribe(


### PR DESCRIPTION
- Correcting the PR merge of the breadcrumb behavior in mobile view
- Names of  show and edit actions added to the breadcrumb

**Before**

https://user-images.githubusercontent.com/81880890/137771723-0270fc36-3ba3-4364-b0ea-bb9662a0ff93.mp4


https://user-images.githubusercontent.com/81880890/137771734-6aad29e2-4c53-468e-a8a7-1e40bfea2ac4.mp4


**Now**


https://user-images.githubusercontent.com/81880890/137771787-74d7bd7e-9b65-4dec-b92c-8dd13c62725e.mp4


https://user-images.githubusercontent.com/81880890/137771950-2eb3f28d-3b9d-449c-8d46-f6a52f270a86.mp4

