### PR TITLE
Fix | breadcrumb title of mainSection

### DIFF
--- a/src/actions/MemberContainer.js
+++ b/src/actions/MemberContainer.js
@@ -225,9 +225,11 @@ function MemberContainerLayout({ docked, subject, height, width, onSubjectPicked
 
     const breadcrumb = (
       <Breadcrumbs separator="|" aria-label="breadcrumb" className={classes.breadcrumbs}>
-        <Typography variant="h6" className={classes.recordTitle}>
-          {mainSectionTitle && `${mainSectionTitle} `}
-        </Typography>
+        {mainSectionTitle && (
+          <Typography variant="h6" className={classes.recordTitle}>
+            {`${mainSectionTitle} `}
+          </Typography>
+        )}
         {dataLink}
         <Typography variant="h6" className={classes.recordTitle}>
           {title || <Skeleton variant="text" width={theme.spacing(5)} />}


### PR DESCRIPTION
The breadcrumb trail only displays the menu section title when this item is a child of a menu section because there are internal paths that are not within a menu section.

**Before**

https://user-images.githubusercontent.com/81880890/139739531-982a6a7a-8fa9-41e4-be1d-0619ca3348b3.mp4

**Now**

https://user-images.githubusercontent.com/81880890/139739598-d3687013-9fa9-4bbc-8c71-9b6444771d66.mp4

