### PR TITLE
Fix | SendToFlow cancel editor

### DIFF
--- a/src/actions/SendToFlow.js
+++ b/src/actions/SendToFlow.js
@@ -64,10 +64,6 @@ const SendToFlow = ({ docked, dataType, onSubjectPicked, height }) => {
         };
       }, []);
 
-    const handleCancel = () => {
-        setContainerState({ actionKey: 'index' });
-    }
-
     const value = useRef(new FormRootValue({
         data_type: {
             id: dataType.id,
@@ -108,7 +104,6 @@ const SendToFlow = ({ docked, dataType, onSubjectPicked, height }) => {
                         onFormSubmit={handleFormSubmit}
                         onSubjectPicked={onSubjectPicked}
                         successControl={ExecutionMonitor}
-                        cancelEditor={handleCancel}
                         value={value.current}/>
         </div>
     );


### PR DESCRIPTION
The action to cancel the form is eliminated so that the default cancel action created in the FormEditor is executed to correct the cancel button bug

**Before**

https://user-images.githubusercontent.com/81880890/141531440-b2a6b588-b492-4402-aec8-2c4868f5d8ef.mp4



**Now**

https://user-images.githubusercontent.com/81880890/141531464-986b0710-ab39-4f58-ad2d-94269c0a4775.mp4

