### PR TITLE
Fix | Export cancel editor

### DIFF
--- a/src/actions/Export.js
+++ b/src/actions/Export.js
@@ -95,10 +95,6 @@ const Export = ({ docked, dataType, onSubjectPicked, height }) => {
 
     const { selectedItems, selector } = containerState;
 
-    const handleCancel = () => {
-        setContainerState({ actionKey: 'index' });
-    }
-
     const value = useRef(new FormRootValue({
         data_type: {
             id: dataType.id,
@@ -186,7 +182,6 @@ const Export = ({ docked, dataType, onSubjectPicked, height }) => {
                             onFormSubmit={handleFormSubmit}
                             onSubjectPicked={onSubjectPicked}
                             successControl={ExecutionMonitor}
-                            cancelEditor={handleCancel}
                             value={value.current}/>
             </div>
         );


### PR DESCRIPTION
The action to cancel the form is eliminated so that the default cancel action created in the FormEditor is executed to correct the cancel button bug

**Before**

https://user-images.githubusercontent.com/81880890/141532722-38baf17a-cc50-40af-ba85-c8cffb9d9f14.mp4

**Now**

https://user-images.githubusercontent.com/81880890/141532738-5cea5ca1-0f6b-4452-956b-d589589a08ad.mp4

