### PR TITLE
Add | Order to Actions

### DIFF
--- a/src/actions/ActionPicker.js
+++ b/src/actions/ActionPicker.js
@@ -56,6 +56,19 @@ function ActionPicker({ disabled, kind, arity, selectedKey, onAction, dataType }
 
     const frame = useRef(null);
 
+    const reorder = (a, b) => {
+      let groupA = a.group ? a.group : 0,
+        groupB = b.group ? b.group : 0;
+
+      if (groupA > groupB) {
+        return 1;
+      }
+      if (groupA < groupB) {
+        return -1;
+      }
+      return 0;
+    };
+
     useEffect(() => {
         if (dataType) {
             const subscription = dataType.config().subscribe(config => {
@@ -90,7 +103,7 @@ function ActionPicker({ disabled, kind, arity, selectedKey, onAction, dataType }
                     }
                 );
 
-                setState({ actions, config });
+                setState({ actions: actions.sort(reorder) , config });
             });
 
             return () => subscription.unsubscribe();

--- a/src/actions/Cross.js
+++ b/src/actions/Cross.js
@@ -472,5 +472,6 @@ export default ActionRegistry.register(Cross, {
             "namespace": "Setup",
             "name": "CrossSharedCollection"
         }
-    ]
+    ],
+    group: 3
 });

--- a/src/actions/DataType.js
+++ b/src/actions/DataType.js
@@ -57,5 +57,6 @@ export default ActionRegistry.register(DataType, {
     kind: ActionKind.collection,
     icon: CenitTypesIcon,
     title: 'Data Type',
-    executable: true
+    executable: true,
+    group: 5
 });

--- a/src/actions/Delete.js
+++ b/src/actions/Delete.js
@@ -202,5 +202,6 @@ export default ActionRegistry.register(Delete, {
     title: 'Delete',
     bulkable: true,
     activeColor: 'secondary',
-    crud: [CRUD.delete]
+    crud: [CRUD.delete],
+    group: 4
 });

--- a/src/actions/Export.js
+++ b/src/actions/Export.js
@@ -193,5 +193,6 @@ const Export = ({ docked, dataType, onSubjectPicked, height }) => {
 export default ActionRegistry.register(Export, {
     bulkable: true,
     icon: SharedCollectionIcon,
-    title: 'Export'
+    title: 'Export',
+    group: 2
 });

--- a/src/actions/Filter.js
+++ b/src/actions/Filter.js
@@ -97,5 +97,6 @@ const Filter = ({ docked, dataType, onSubjectPicked, height }) => {
 export default ActionRegistry.register(Filter, {
     kind: ActionKind.collection,
     icon: FilterIcon,
-    title: 'Filter'
+    title: 'Filter',
+    group: 5
 });

--- a/src/actions/Import.js
+++ b/src/actions/Import.js
@@ -134,5 +134,6 @@ export default ActionRegistry.register(Import, {
     kind: ActionKind.collection,
     icon: ImportIcon,
     title: 'Import',
-    crud: [CRUD.create, CRUD.update]
+    crud: [CRUD.create, CRUD.update],
+    group: 2
 });

--- a/src/actions/PullImport.js
+++ b/src/actions/PullImport.js
@@ -409,5 +409,6 @@ export default ActionRegistry.register(PullImport, {
             "namespace": "Setup",
             "name": "Collection"
         }
-    ]
+    ],
+    group: 2
 });

--- a/src/actions/Share.js
+++ b/src/actions/Share.js
@@ -102,5 +102,6 @@ export default ActionRegistry.register(Share, {
     onlyFor: [{
         "namespace": "Setup",
         "name": "Collection"
-    }]
+    }],
+    group: 3
 });

--- a/src/actions/ShredCollection.js
+++ b/src/actions/ShredCollection.js
@@ -74,5 +74,6 @@ export default ActionRegistry.register(ShredCollection, {
     arity: 1,
     icon: ShredIcon,
     title: 'Shred',
-    onlyFor: [{ namespace: 'Setup', name: 'Collection' }]
+    onlyFor: [{ namespace: 'Setup', name: 'Collection' }],
+    group: 4
 });

--- a/src/actions/ShredTenant.js
+++ b/src/actions/ShredTenant.js
@@ -83,5 +83,6 @@ export default ActionRegistry.register(ShredTenant, {
     arity: 1,
     icon: ShredIcon,
     title: 'Shred',
-    onlyFor: [{ namespace: '', name: 'Account' }]
+    onlyFor: [{ namespace: '', name: 'Account' }],
+    group: 4
 });

--- a/src/actions/SwitchTenant.js
+++ b/src/actions/SwitchTenant.js
@@ -17,5 +17,6 @@ export default ActionRegistry.register(SwitchTenant, {
     title: 'Switch',
     executable: true,
     arity: 1,
-    onlyFor: [TenantTypeSelector]
+    onlyFor: [TenantTypeSelector],
+    group: 5
 });

--- a/src/actions/SwitchTenantLock.js
+++ b/src/actions/SwitchTenantLock.js
@@ -126,5 +126,6 @@ export default ActionRegistry.register(SwitchTenantLock, {
     icon: SwitchLockIcon,
     title: contextTitle,
     executable: true,
-    onlyFor: [TenantTypeSelector]
+    onlyFor: [TenantTypeSelector],
+    group: 5
 });


### PR DESCRIPTION
Shares are reorganized so that they are grouped by similarity
A new property is created (''group") in the components of each action to be able to have a criterion by which you order because the actions are rendered dynamically depending on when they were registered and an order is not guaranteed for this

They were grouped: 

- delete, sherd
- export, import, pull-import
- cross, share

**Before**

https://user-images.githubusercontent.com/81880890/142071974-70311b87-bacb-49d1-83d3-046377202365.mp4

**Now**

https://user-images.githubusercontent.com/81880890/142071990-c2948096-2b0d-4fdf-a291-9039f36a3164.mp4

