### PR TITLE
Fix|  Render Tags

### DIFF
--- a/src/components/OauthScopeControl.js
+++ b/src/components/OauthScopeControl.js
@@ -284,7 +284,9 @@ export default function OauthScopeControl(props) {
     const { scopes, readOnly, disabled, value } = props;
 
     const renderTags = (tagValue, getTagProps) =>
-        tagValue.map((option, index) => {
+      tagValue
+        .filter((val) => SCOPES.includes(val))
+        .map((option, index) => {
             const tagProps = getTagProps({ index });
             if (readOnly) {
                 tagProps.onDelete = undefined;


### PR DESCRIPTION
The representation of the labels has been corrected so that it only shows the values ​​of the scopes, taking into account the cases where there are scopes for specific data_types

**Before**

https://user-images.githubusercontent.com/81880890/143933204-70eec9c1-c28f-4584-bc96-ffb7ae42148a.mp4


**Now**

https://user-images.githubusercontent.com/81880890/143932420-21b35e09-2778-4ed5-a8ae-26c20da7e69b.mp4


https://user-images.githubusercontent.com/81880890/143932643-ebe8f546-6758-4d1c-8809-d0eebf0e2521.mp4

