### PR TITLE
Fix| FormEditor scroll-y

### DIFF
--- a/src/components/FormEditor.js
+++ b/src/components/FormEditor.js
@@ -76,7 +76,7 @@ const useStyles = makeStyles(theme => ({
         paddingRight: '15%',
     },
     trailing: {
-        height: `${theme.spacing(8)}px`
+        height: `${theme.spacing(1)}px`
     },
     fabBack: {
         position: 'absolute',


### PR DESCRIPTION
Unnecessary scrolling is eliminated

**Before**

https://user-images.githubusercontent.com/81880890/147689166-5f1adb23-5d58-4606-9614-d6058f0820a3.mp4



**Now**

https://user-images.githubusercontent.com/81880890/147689037-d2572285-ba44-4546-85d9-d60b43570807.mp4

