### PR TITLE
Fix| Menu group mobile layout

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -42,6 +42,10 @@ const useStyles = makeStyles(theme => ({
         boxShadow: '0 4px 8px 0 rgba(55, 71, 79, .3)',
         borderTopLeftRadius: theme.spacing(1),
         borderTopRightRadius: theme.spacing(1),
+        width: '80vw',
+        [theme.breakpoints.up('sm')]: {
+            width: 'auto'
+        },
     },
     groupHeader: {
         padding: theme.spacing(1.5, 4, 1.5, 6),


### PR DESCRIPTION
Resize items to be the same size in mobile view

**Before**

https://user-images.githubusercontent.com/81880890/147692387-059f4f3e-3653-43c0-9fcf-129dfe3d7b9d.mp4


**Now**

https://user-images.githubusercontent.com/81880890/147691924-77551743-e74c-40a7-bbfb-7d22856097ba.mp4

